### PR TITLE
node.js ver. up (18), react ver. up (18)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
         "@parcel/packager-ts": "^2.5.0",
         "@parcel/transformer-sass": "^2.5.0",
         "@parcel/transformer-typescript-types": "^2.5.0",
-        "@types/node": "^14.14.16",
-        "@types/react": "^17.0.44",
-        "@types/react-dom": "^17.0.16",
+        "@types/node": "^18.19.3",
+        "@types/react": "^18.2.45",
+        "@types/react-dom": "^18.2.18",
         "@types/react-router-dom": "^5.3.3",
         "buffer": "^6.0.3",
         "eslint-config-prettier": "^8.5.0",
@@ -42,8 +42,8 @@
         "npm": ">=7.20.3"
       },
       "peerDependencies": {
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react": ">=17 <19",
+        "react-dom": ">=17 <19"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1667,10 +1667,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.19.tgz",
-      "integrity": "sha512-4nhBPStMK04rruRVtVc6cDqhu7S9GZai0fpXgPXrFpcPX6Xul8xnrjSdGB4KPBVYG/R5+fXWdCM8qBoiULWGPQ==",
-      "dev": true
+      "version": "18.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
+      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1691,9 +1694,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.44",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
-      "integrity": "sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==",
+      "version": "18.2.45",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.45.tgz",
+      "integrity": "sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -1702,12 +1705,12 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.16.tgz",
-      "integrity": "sha512-DWcXf8EbMrO/gWnQU7Z88Ws/p16qxGpPyjTKTpmBSFKeE+HveVubqGO1CVK7FrwlWD5MuOcvh8gtd0/XO38NdQ==",
+      "version": "18.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.18.tgz",
+      "integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
       "dev": true,
       "dependencies": {
-        "@types/react": "^17"
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-router": {
@@ -7307,6 +7310,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -8592,10 +8601,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.19.tgz",
-      "integrity": "sha512-4nhBPStMK04rruRVtVc6cDqhu7S9GZai0fpXgPXrFpcPX6Xul8xnrjSdGB4KPBVYG/R5+fXWdCM8qBoiULWGPQ==",
-      "dev": true
+      "version": "18.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
+      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -8616,9 +8628,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.44",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
-      "integrity": "sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==",
+      "version": "18.2.45",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.45.tgz",
+      "integrity": "sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -8627,12 +8639,12 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.16.tgz",
-      "integrity": "sha512-DWcXf8EbMrO/gWnQU7Z88Ws/p16qxGpPyjTKTpmBSFKeE+HveVubqGO1CVK7FrwlWD5MuOcvh8gtd0/XO38NdQ==",
+      "version": "18.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.18.tgz",
+      "integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
       "dev": true,
       "requires": {
-        "@types/react": "^17"
+        "@types/react": "*"
       }
     },
     "@types/react-router": {
@@ -12858,6 +12870,12 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "unique-string": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
     "query-string": "^7.1.1"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": ">=17 <19",
+    "react-dom": ">=17 <19"
   },
   "devDependencies": {
     "@parcel/packager-ts": "^2.5.0",
     "@parcel/transformer-sass": "^2.5.0",
     "@parcel/transformer-typescript-types": "^2.5.0",
-    "@types/node": "^14.14.16",
-    "@types/react": "^17.0.44",
-    "@types/react-dom": "^17.0.16",
+    "@types/node": "^18.19.3",
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
     "@types/react-router-dom": "^5.3.3",
     "buffer": "^6.0.3",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
- React 18 을 사용하는 Repo 에서 이 package 를 사용할 수 없는 문제가 있었습니다.
  - react 의 Peer dependency 를 17과 18을 모두 허용하게 변경했습니다
  - 프로젝트 내부에서 사용하는 node 와 react 버전을 모두 18로 상향 했습니다.